### PR TITLE
CSVダウンロードのファイル名に名前をつけられるようにする

### DIFF
--- a/docs/example/dashboard-01/index.html
+++ b/docs/example/dashboard-01/index.html
@@ -224,6 +224,13 @@ const deviceSegments = {
   "5890222d3601a6183b69f14f": 'PC'
 }
 
+const params = {
+  project_name: 'ProjectA',
+  start_date: '20170920',
+  end_date: '20170922'
+}
+const CSV_FILE_NAME = `Report ${params.project_name} (${params.start_date}〜${params.end_date})`;
+
 const bindData = {
   deviceSegments: Object.keys(deviceSegments),
   deviceSegmentLabels: deviceSegments,
@@ -232,7 +239,8 @@ const bindData = {
     "58902caa7048639a5ba53b17": 'newspicks',
     "58902d517048639a5ba53b26": 'facebook',
     "58902e8c7048639a5ba53b3a": 'twitter'
-  }
+  },
+  defaultCsvFileName: CSV_FILE_NAME
 }
 
 for (let k in bindData) {
@@ -244,14 +252,6 @@ EasyDC.Store.registerRepresentation('linkFormat', (v, d, k) => {
     return `<a href="${v}" target="_blank">${v}</a>`
   }).join(', ')
 })
-
-const params = {
-  project_name: 'ProjectA',
-  start_date: '20170920',
-  end_date: '20170922'
-}
-const CSV_FILE_NAME = `Report ${params.project_name} (${params.start_date}〜${params.end_date})`;
-EasyDC.Store.setCsvFileNames({default: CSV_FILE_NAME});
 
 EasyDC.run(true)
 

--- a/docs/example/dashboard-01/index.html
+++ b/docs/example/dashboard-01/index.html
@@ -245,6 +245,13 @@ EasyDC.Store.registerRepresentation('linkFormat', (v, d, k) => {
   }).join(', ')
 })
 
+const params = {
+  project_name: 'ProjectA',
+  start_date: '20170920',
+  end_date: '20170922'
+}
+const CSV_FILE_NAME = `Report ${params.project_name} (${params.start_date}〜${params.end_date})`;
+EasyDC.Store.setCsvFileNames({default: CSV_FILE_NAME});
 
 EasyDC.run(true)
 

--- a/docs/example/dashboard-01/index.html
+++ b/docs/example/dashboard-01/index.html
@@ -34,11 +34,17 @@
     labels="セグメント,PV,UU,セッション数,セッション毎平均PV数,セッション毎平均時間,離脱数,コンバーション数,最終PV時間"
   ></easy-dc-dataset>
 
+  <easy-dc-dataset
+    csv='../morley.csv'
+    dataset="morley"
+  ></easy-dc-dataset>
+
 <div id="krt-dc-dashboard">
   <div class="container" style="display: flex; flex-direction:row; align-items:center; justify-content:space-around">
 
     <div class="buttons">
-      <csv-download-button></csv-download-button>
+      <csv-download-button :file-name="defaultCsvFileName"></csv-download-button>
+      <csv-download-button dataset="morley"></csv-download-button>
       <reset-all-button></reset-all-button>
     </div>
 
@@ -94,6 +100,13 @@
     :descending=true
     :cap=5>
   </list-row>
+
+  <list-row
+    dataset="morley"
+    title='morley'
+    dimension='d.Expt'
+    reduce='d.Run'
+  ></list-row>
 
   <ordinal-bar
     title='ordinal-bar'

--- a/libs/chart/csv-download-button.vue
+++ b/libs/chart/csv-download-button.vue
@@ -1,22 +1,41 @@
 <template>
   <div class="download-csv-button">
-    <a class="btn btn-outline-primary" @click="downloadCSV('data')">
+    <a class="btn btn-outline-primary" @click="downloadCSV()">
       <i class="fa fa-cloud-download" aria-hidden="true"></i> CSV ダウンロード
     </a>
   </div>
 </template>
 
 <script lang="js">
-import Store from '../store'
+import Store from '../store';
 
 export default {
+  props: {
+    fileName: {
+      type: String,
+      default: 'data',
+    },
+    dataset: {
+      type: String,
+      default: 'default',
+    },
+    dimensionName: {
+      type: String,
+    },
+    labels: {
+      type: Object,
+    },
+  },
   methods: {
-    downloadCSV: function(data) {
-      return EasyDC.Store.downloadCSV(data)
-    }
-  }
-}
-
+    downloadCSV: function() {
+      const options = {
+        dataset: this.dataset,
+        labels: this.labels,
+      };
+      return EasyDC.Store.downloadCSV(this.fileName, this.dimensionName, options);
+    },
+  },
+};
 </script>
 
 <style scoped>

--- a/libs/store.js
+++ b/libs/store.js
@@ -68,6 +68,9 @@ class DashboardStore {
     this._linkFormatters = {
       default: (v) => v
     };
+
+    this._csvFileNames = {
+    };
   }
 
   setBindData(name, data) {
@@ -282,11 +285,25 @@ class DashboardStore {
     this._defaultTheme = theme
   }
 
+  setDefaultTheme(theme) {
+    this._defaultTheme = theme;
+  }
+
+  setCsvFileNames(filenames) {
+    this._csvFileNames = filenames;
+  }
+
   downloadCSV(filename, dimensionName='_all', options={}) {
     const {
       dataset = 'default',
       labels = this._labels[dataset][''] || {},
     } = options;
+
+    if(!this._dimensions[dataset]) {
+      return console.log('dataset not registered')
+    }
+
+    filename = this._csvFileNames[dataset] || filename;
 
     if (dimensionName === '_all' && !this._dimensions[dataset][dimensionName]) {
       let idx = 0;

--- a/libs/store.js
+++ b/libs/store.js
@@ -69,8 +69,6 @@ class DashboardStore {
       default: (v) => v
     };
 
-    this._csvFileNames = {
-    };
   }
 
   setBindData(name, data) {
@@ -285,14 +283,6 @@ class DashboardStore {
     this._defaultTheme = theme
   }
 
-  setDefaultTheme(theme) {
-    this._defaultTheme = theme;
-  }
-
-  setCsvFileNames(filenames) {
-    this._csvFileNames = filenames;
-  }
-
   downloadCSV(filename, dimensionName='_all', options={}) {
     const {
       dataset = 'default',
@@ -302,8 +292,6 @@ class DashboardStore {
     if(!this._dimensions[dataset]) {
       return console.log('dataset not registered')
     }
-
-    filename = this._csvFileNames[dataset] || filename;
 
     if (dimensionName === '_all' && !this._dimensions[dataset][dimensionName]) {
       let idx = 0;


### PR DESCRIPTION
close:https://github.com/plaidev/easy-dc-dash/issues/113

**step**
1. EasyDC.Store.setBindDataでcsvファイル名に使いたい変数を登録する
https://github.com/plaidev/easy-dc-dash/blob/93caa922d1b0032f2cd894618cd680c5329a11cb/docs/example/dashboard-01/index.html#L240-L261
2. download-csv-buttonのpropsに登録した変数を渡す
https://github.com/plaidev/easy-dc-dash/blob/93caa922d1b0032f2cd894618cd680c5329a11cb/docs/example/dashboard-01/index.html#L46

**複数datasetでdownloadするcsvファイルを分けたい場合**

- https://github.com/plaidev/easy-dc-dash/blob/93caa922d1b0032f2cd894618cd680c5329a11cb/docs/example/dashboard-01/index.html#L37-L40
- https://github.com/plaidev/easy-dc-dash/blob/93caa922d1b0032f2cd894618cd680c5329a11cb/docs/example/dashboard-01/index.html#L47

default以外のdatasetの場合も同様にsetBindDataに変数を登録して :file-name="nameForOther" のように渡せばいい

ついでにprops経由でdownloadCSVにoptionを渡せるようにした
  - dimensionName
  - labels