### PR TITLE
tooltip周りのコード整理

### DIFF
--- a/libs/chart/_base.js
+++ b/libs/chart/_base.js
@@ -240,8 +240,10 @@ export default {
       return false
     },
     valueAccessor: function() {
-      if (this.isRateReducer) return (d) => {
-        return (d.value.count === 0 ? 0 : d.value.value / d.value.count)
+      if (this.isRateReducer) {
+        return (d) => {
+          return (d.value.count === 0 ? 0 : d.value.value / d.value.count)
+        }
       }
       return null;
     },
@@ -704,9 +706,10 @@ export default {
     }
     if (this.valueAccessor) chart.valueAccessor(this.valueAccessor);
     if (chart.x) {
-      if (this.dimensionScale.domain) chart.x(this.dimensionScale.domain(this.dimensionRange));
-      if (this.dimensionScale.unit) chart.xUnits(this.dimensionScale.unit);
+      if (this.dimensionScale.domain) chart.x(this.dimensionScale.domain(this.dimensionRange))
     }
+    if (chart.xUnits && this.dimensionScale.unit) chart.xUnits(this.dimensionScale.unit)
+
     if (this.extraDimensionExtractor) {
       chart.keyAccessor((d) => {
         return d.key[0]

--- a/libs/chart/_base.js
+++ b/libs/chart/_base.js
@@ -401,6 +401,10 @@ export default {
       }
       else _domain = null
 
+      if (unit === 'ordinal') {
+        _format = (k) => this.getLabel(k)
+      }
+
       return {
         domain: _domain,
         interval: _interval,

--- a/libs/chart/_base.js
+++ b/libs/chart/_base.js
@@ -16,56 +16,6 @@ import ChartLink from '../components/chart-link.vue'
 // データの処理、レイアウト関係の処理、汎用のパーツの組み込みが混ざっているので分離
 
 
-function generateScales(scaleCode) {
-  if (!scaleCode) return {};
-
-  let [scale, unit] = scaleCode.split('.');
-  if (scale == 'time' && !unit) unit = 'day'
-  if (scale == 'ordinal' && !unit) unit = 'ordinal'
-
-  let _scale, _interval, _unit, _format, _domain;
-
-  // scale
-  if (scale == 'time') _scale = d3.time.scale;
-  else _scale = d3.scale[scale];
-
-  // interval
-  if (scale == 'time' && TIME_INTERVALS[unit]) {
-    _interval = TIME_INTERVALS[unit]
-  }
-
-  // unit
-  if (scale == 'time' && TIME_INTERVALS[unit]) {
-    _unit = TIME_INTERVALS[unit].range
-  }
-  if (scale == 'ordinal' && dc.units[unit]) {
-    _unit = dc.units[unit]
-  }
-
-  // format
-  if (scale == 'time') {
-    if (unit == 'month') _format = TIME_FORMATS.ym
-    else if (unit == 'day') _format = TIME_FORMATS.ymd
-    else if (unit == 'hour') _format = TIME_FORMATS.ymdh
-    else if (unit == 'minute') _format = TIME_FORMATS.ymdhm
-    else if (unit == 'second') _format = TIME_FORMATS.ymdhms
-    else _format = TIME_FORMATS[unit]
-  }
-
-  if (_scale) {
-    if (unit !== 'ordinal') _domain = _scale().domain
-    else _domain = _scale
-  }
-  else _domain = null
-
-  return {
-    domain: _domain,
-    interval: _interval,
-    unit: _unit,
-    format: _format
-  }
-}
-
 export default {
 
   template: `
@@ -318,10 +268,10 @@ export default {
       return this.reducer.all();
     },
     dimensionScale: function () {
-      return generateScales(this.scale)
+      return this.generateScales(this.scale)
     },
     extraDimensionScale: function () {
-      return generateScales(this.extraScale)
+      return this.generateScales(this.extraScale)
     },
     cardSettings: function() {
       const theme = Store.getTheme(this.theme)
@@ -407,6 +357,57 @@ export default {
   },
 
   methods: {
+    generateScales: function(scaleCode) {
+      if (!scaleCode) return {};
+
+      let [scale, unit] = scaleCode.split('.');
+      if (!unit) {
+        if (scale == 'time') unit = 'day'
+        else if (scale == 'ordinal') unit = 'ordinal'
+      }
+
+      let _scale, _interval, _unit, _format, _domain;
+
+      // scale
+      if (scale == 'time') _scale = d3.time.scale;
+      else _scale = d3.scale[scale];
+
+      // interval
+      if (scale == 'time' && TIME_INTERVALS[unit]) {
+        _interval = TIME_INTERVALS[unit]
+      }
+
+      // unit
+      if (scale == 'time' && TIME_INTERVALS[unit]) {
+        _unit = TIME_INTERVALS[unit].range
+      }
+      if (scale == 'ordinal' && dc.units[unit]) {
+        _unit = dc.units[unit]
+      }
+
+      // format
+      if (scale == 'time') {
+        if (unit == 'month') _format = TIME_FORMATS.ym
+        else if (unit == 'day') _format = TIME_FORMATS.ymd
+        else if (unit == 'hour') _format = TIME_FORMATS.ymdh
+        else if (unit == 'minute') _format = TIME_FORMATS.ymdhm
+        else if (unit == 'second') _format = TIME_FORMATS.ymdhms
+        else _format = TIME_FORMATS[unit]
+      }
+
+      if (_scale) {
+        if (unit !== 'ordinal') _domain = _scale().domain
+        else _domain = _scale
+      }
+      else _domain = null
+
+      return {
+        domain: _domain,
+        interval: _interval,
+        unit: _unit,
+        format: _format
+      }
+    },
     updateContainerInnerSize: function({isFullscreen}) {
       this.isFullscreen = isFullscreen
       // not mounted

--- a/libs/chart/_base.js
+++ b/libs/chart/_base.js
@@ -105,6 +105,9 @@ export default {
     },
 
     // formatter
+    tooltipFormat: {
+      type: String
+    },
     linkFormatter: {
       type: String
     },
@@ -303,6 +306,20 @@ export default {
     },
     colors: function() {
       return this.colorSettings.ordinal
+    },
+    tooltipFormatter: function() {
+      let key, extraKey, val, _val
+      key = this.dimensionScale.format || ((k) => k)
+      layer = this.extraDimensionScale.format || ((k) => k)
+
+      if (!this.tooltipFormat) {
+        val = (n) => d3.round(n, 2)
+      }
+      else {
+        val = d3.format(this.tooltipFormat)
+      }
+
+      return {key, layer, val}
     },
     textSelector: function() {
       if(this.chartType === 'bubbleChart') return `#${this.id} .node text`

--- a/libs/chart/_base.js
+++ b/libs/chart/_base.js
@@ -351,7 +351,6 @@ export default {
         case 'seriesChart':
         case 'compositeChart':
           return (d, i) => {
-            console.log('coordinations', d)
             const data = {}
             // coordinationGrid
             // pointのマウスオーバー
@@ -380,7 +379,6 @@ export default {
 
         case 'rowChart':
           return (d, i) => {
-            console.log('row', d)
             let v = d.value
             if (valueAccessor) v = valueAccessor(d)
             return {
@@ -392,7 +390,6 @@ export default {
 
         case 'pieChart':
           return (d, i) => {
-            console.log('pie', d)
             const rate = (d.endAngle - d.startAngle) / (2*Math.PI) * 100;
             let v = d.value
             if (valueAccessor) v = valueAccessor(d)
@@ -406,7 +403,6 @@ export default {
 
         case 'bubbleChart':
           return (d, i) => {
-            console.log('bubble', d)
             const key = _formats.key(d.key)
             const labels = [this.xAxisLabel, this.yAxisLabel, this.radiusLabel]
             const vals = {}
@@ -420,7 +416,6 @@ export default {
 
         case 'geoChoroplethChart':
           return (d, i) => {
-            console.log('geo', d)
             const _key = d3.format('02d')(d.properties.id)
             const value = this.reducerAll.filter(x => x.key === _key)[0].value
             return {
@@ -432,7 +427,6 @@ export default {
 
         case 'heatMap':
           return (d, i) => {
-            console.log('heatmap', d)
             const xAxisLabel = this.getLabel(this.xAxisLabel || this.dimensionKeys[0] || 'x')
             const yAxisLabel = this.getLabel(this.yAxisLabel || this.dimensionKeys[1] || 'y')
             let v = d.value

--- a/libs/chart/bubble.vue
+++ b/libs/chart/bubble.vue
@@ -159,22 +159,6 @@ export default {
       else if(val instanceof Object || typeof val === 'object') {
         if(val.per != undefined) return val.per
       }
-    },
-    showTooltip: function(d) {
-      const fill = d3.event.target.getAttribute('fill')
-      const _format = this.dimensionScale.format
-      const v = d.value
-      const k = d.key
-      const _k = _format ? _format(k) : k
-      const data = {
-        key: _k,
-        vals: {
-          [this.xAxisLabel]: v[this.xAxisLabel].per ? roundDecimalFormat(v[this.xAxisLabel].per, 2) : v[this.xAxisLabel],
-          [this.yAxisLabel]: v[this.yAxisLabel].per ? roundDecimalFormat(v[this.yAxisLabel].per, 2) : v[this.yAxisLabel],
-          [this.radiusLabel]: v[this.radiusLabel].per ? roundDecimalFormat(v[this.radiusLabel].per, 2) : v[this.radiusLabel]
-        }
-      }
-      this.$refs.tooltip.show(data, fill)
     }
   },
   mounted: function() {

--- a/libs/chart/filter-stacked-bar.vue
+++ b/libs/chart/filter-stacked-bar.vue
@@ -42,6 +42,15 @@ export default {
       })
       return stackKeys
     }
+    // tooltipAccessor: function() {
+    //   const _formats = this.tooltipFormatter
+    //   return (d, i) => {
+    //     return {
+    //       key: `${_formats.key(d.data.key)}[${d.layer}]`,
+    //       val: _formats.val(d.data.value[d.layer])
+    //     }
+    //   }
+    // }
   },
   methods: {
     stackSecond: function (group) {
@@ -84,15 +93,6 @@ export default {
         return d.value[k] || 0
       }
     },
-    showTooltip: function(d) {
-      const fill = d3.event.target.getAttribute('fill')
-      const k = this.getLabel(d.data.key)
-      const data = {
-        key: `${k}[${d.layer}]`,
-        val: d.data.value[d.layer]
-      }
-      this.$refs.tooltip.show(data, fill)
-    }
   },
   mounted: function() {
     const chart = this.chart;

--- a/libs/chart/filter-stacked-bar.vue
+++ b/libs/chart/filter-stacked-bar.vue
@@ -76,7 +76,7 @@ export default {
           // then produce multivalue key/value pairs
           return Object.keys(m).map((k) => {
             let key = k
-            if (_format) key = _format.parse(k)
+            if (_format && _format.parse) key = _format.parse(k)
               // if (this.scale === 'time')
                 // key = ymdFormat.parse(k)
             return {key: [key], value: m[k]};

--- a/libs/chart/geo-jp.vue
+++ b/libs/chart/geo-jp.vue
@@ -38,20 +38,6 @@ export default {
         .range([z, p])
     }
   },
-  methods: {
-    showTooltip(d) {
-      const fill = d3.event.target.getAttribute('fill')
-      const _key = ('0'+d.properties.id).slice(-2)
-      const data = {
-        key: d.properties.nam_ja,
-        val: this.extractValue(_key)
-      }
-      this.$refs.tooltip.show(data, fill)
-    },
-    extractValue(_key) {
-      return this.reducerAll.filter(x => x.key === _key)[0].value
-    }
-  },
   mounted: function() {
     const chart = this.chart;
     const max = this.reducer.top(1)[0].value;

--- a/libs/chart/heat-map.vue
+++ b/libs/chart/heat-map.vue
@@ -67,21 +67,6 @@ export default {
         .range(range);
     }
   },
-  methods: {
-    showTooltip: function(d) {
-      const fill = d3.event.target.getAttribute('fill')
-      const xAxisLabel = this.getLabel(this.xAxisLabel || this.dimensionKeys[0] || 'x')
-      const yAxisLabel = this.getLabel(this.yAxisLabel || this.dimensionKeys[1] || 'y')
-      const data = {
-        keys: {
-          [xAxisLabel]: this.getLabel(d.key[0]),
-          [yAxisLabel]: this.getLabel(d.key[1]),
-        },
-        val: d.value
-      }
-      this.$refs.tooltip.show(data, fill)
-    }
-  },
   mounted: function() {
     const chart = this.chart;
 

--- a/libs/chart/list-row.vue
+++ b/libs/chart/list-row.vue
@@ -49,14 +49,6 @@ export default {
     }
   },
   methods: {
-    showTooltip: function(d) {
-      const fill = d3.event.target.getAttribute('fill')
-      const data = {
-        key: this.getLabel(d.key),
-        val: d.value
-      }
-      this.$refs.tooltip.show(data, fill)
-    },
     keyTextPostProcess: function(key) {
       let label = this.getLabel(key)
       return label.length > 20 ? label.substring(0,20)+'...' : label

--- a/libs/chart/multi-dimension-pie.vue
+++ b/libs/chart/multi-dimension-pie.vue
@@ -27,17 +27,6 @@ export default {
         return v.join(',');
       }
       return Store.registerDimension(this.dimensionName, grouping, {dataset: this.dataset});
-    },
-    tooltipAccessor: function() {
-      return (d, i) => {
-        const _rate = (d.endAngle - d.startAngle) / (2*Math.PI) * 100;
-        const rate = roundDecimalFormat(_rate, 2)
-        return {
-          key: d.data.key,
-          val: d.value,
-          rate: rate
-        }
-      }
     }
   },
 

--- a/libs/chart/ordinal-bar.vue
+++ b/libs/chart/ordinal-bar.vue
@@ -48,17 +48,6 @@ export default {
       return this.removeEmptyRows ? removeEmptyBins(group) : group
     }
   },
-  methods: {
-    showTooltip: function(d) {
-      const fill = d3.event.target.getAttribute('fill')
-      const _format = this.dimensionScale.format
-      const data = {
-        key: _format ? _format(d.data.key) : d.data.key,
-        val: d.data.value
-      }
-      this.$refs.tooltip.show(data, fill)
-    }
-  },
   mounted: function() {
     const chart = this.chart;
     chart

--- a/libs/chart/segment-pie.vue
+++ b/libs/chart/segment-pie.vue
@@ -49,17 +49,6 @@ export default {
         return Object.keys(this.segments)
       }
       return []
-    },
-    tooltipAccessor: function() {
-      return (d, i) => {
-        const _rate = (d.endAngle - d.startAngle) / (2*Math.PI) * 100;
-        const rate = roundDecimalFormat(_rate, 2)
-        return {
-          key: this.segmentLabel(d.data.key),
-          val: d.value,
-          rate: rate
-        }
-      }
     }
   },
 

--- a/libs/chart/segment-pie.vue
+++ b/libs/chart/segment-pie.vue
@@ -64,19 +64,15 @@ export default {
   },
 
   methods: {
-    segmentLabel: function(segmentId) {
-      let label = segmentId;
-      if (this.labels && segmentId in this.labels) {
-        label = this.labels[segmentId]
+    getLabel: function(key) {
+      if (this.segments instanceof Object && key in this.segments) {
+        return this.segments[key]
       }
-      else if (this.segments instanceof Object && this.segments[segmentId]) {
-        label = this.segments[segmentId]
-      }
-      else {
-        label = Store.getLabel(segmentId)
-      }
-      return label;
-    }
+      return Store.getLabel(key, {
+        dataset: this.dataset,
+        chartName: this.id
+      })
+    },
   },
 
   watch: {
@@ -90,9 +86,12 @@ export default {
 
   mounted: function() {
     const chart = this.chart;
+    const _label = this.showLabel ? (d => this.getLabel(d.key)) : d => null
+
     chart
       .othersLabel(this.othersLabel)
-    this.showLabel ? chart.label(d => this.segmentLabel(d.key)) : chart.label(d => null)
+      .label(_label)
+
     if(this.cap && this.cap > 0) chart.slicesCap(this.cap)
     return chart
   },

--- a/libs/chart/series.vue
+++ b/libs/chart/series.vue
@@ -63,36 +63,7 @@ export default {
       return d3.extent(all, (d) => d.key[1])
     }
   },
-  methods: {
-    showTooltip: function(d) {
-      const _format = this.dimensionScale.format
-      const fill = d3.event.target.getAttribute('fill');
-      const stroke = d3.event.target.getAttribute('stroke');
-      const color = fill || stroke;
 
-      if (d.x != undefined && d.y != undefined) {
-        const key = d.layer
-        const vals = {
-          x: _format ? _format(d.x) : d.x,
-          y: d.y
-        }
-        const data = {
-          key: key,
-          vals: vals
-        }
-        this.$refs.tooltip.show(data, color)
-      }
-      else {
-        const key = d.name
-        const vals = d.values.map(_d => _d.y).reduce((a,b) => a+b);
-        const data = {
-          key: key,
-          val: vals
-        }
-        this.$refs.tooltip.show(data, color)
-      }
-    }
-  },
   mounted: function() {
     const chart = this.chart;
 

--- a/libs/chart/stacked-lines.vue
+++ b/libs/chart/stacked-lines.vue
@@ -15,6 +15,9 @@ export default {
     },
     scale: {
       default: 'linear'
+    },
+    extraScale: {
+      default: 'ordinal'
     }
   },
 
@@ -60,11 +63,11 @@ export default {
     const lineNum = _reducer(dim.top(1)[0] || {}).length;
 
     chart
-      .group(this.combinedGroup, this.getLabel(this.getReduceKey(0)), this.generateValueAccessor(0))
+      .group(this.combinedGroup, this.getReduceKey(0), this.generateValueAccessor(0))
       .renderArea(true)
     for (let i=1; i<lineNum; i++) {
       chart
-        .stack(this.combinedGroup, this.getLabel(this.getReduceKey(i)), this.generateValueAccessor(i))
+        .stack(this.combinedGroup, this.getReduceKey(i), this.generateValueAccessor(i))
         .hidableStacks(true)
     }
     // FIXME:

--- a/libs/chart/week-row.vue
+++ b/libs/chart/week-row.vue
@@ -81,24 +81,13 @@ export default {
         return cnt > 0 ? p.value.value / cnt: 0;
       }
     },
-    dimensionScale: function() {
-      return {
-        domain: d3.scale.linear().domain
-      }
-    },
+    // dimensionScale: function() {
+    //   return {
+    //     domain: d3.scale.linear().domain
+    //   }
+    // },
     dimensionRange: function() {
       return [0, 6]
-    }
-  },
-
-  methods: {
-    showTooltip: function(d) {
-      const fill = d3.event.target.getAttribute('fill')
-      const data = {
-        key: this.getLabel(d.key),
-        val: d.value.value
-      }
-      this.$refs.tooltip.show(data, fill)
     }
   },
 


### PR DESCRIPTION
refs #111 

* tooltipで表示すべきデータはdc.jsのチャートタイプによって異なるので、baseに全てまとめた
   - scale, extraScale, valueAccessorなど、tooltipでも考慮すべき処理をまとめた
* `<chart tooltip-format=".02f">`のような形式にも対応
   - https://github.com/plaidev/easy-dc-dash/compare/master...feature/111-2#diff-b00233b69d7e7ab49d866fab50ce9827R321
