### PR TITLE
DOM Element型の設定としてCommon Dimensionをサポート

### DIFF
--- a/docs/example/dashboard-04/index.html
+++ b/docs/example/dashboard-04/index.html
@@ -6,19 +6,28 @@
     <link href="../../../dist/bundle.css" rel="stylesheet" type="text/css" />
   </head>
 
+  <easy-dc-dataset>
+    <dimension name="d1" field="d.d1"></dimension>
+    <dimension name="d2" field="d.d2"></dimension>
+  </easy-dc-dataset>
+
+  <easy-dc-dataset dataset="other">
+    <dimension name="d1" field="d.dd1"></dimension>
+    <dimension name="d2" field="d.dd2"></dimension>
+  </easy-dc-dataset>
 
   <body style="display: flex; justify-content: center; align-items: flex-start; background-color: #b0b7b7; flex-wrap: wrap">
 
     <multidim-pie
       title="TITLE"
-      dimension="$D1"
+      dimension="$d1"
       reduce="v"
     ></multidim-pie>
 
     <multidim-pie
       dataset="other"
       title="other square"
-      dimension="$D2"
+      dimension="$d2"
       reduce="v2"
     ></multidim-pie>
 
@@ -38,12 +47,6 @@
       ], {
         dataset: 'other'
       })
-
-      EasyDC.Store.registerDimension('$D1', (d) => d.d1)
-      EasyDC.Store.registerDimension('$D1', (d) => d.dd1, {dataset: 'other'})
-
-      EasyDC.Store.registerDimension('$D2', (d) => d.d2)
-      EasyDC.Store.registerDimension('$D2', (d) => d.dd2, {dataset: 'other'})
 
       EasyDC.run()
     </script>

--- a/libs/autorun.js
+++ b/libs/autorun.js
@@ -39,6 +39,16 @@ function autoLoad() {
       isUTC
     }
 
+    const _commonDims = el.getElementsByTagName('dimension')
+    const commonDims = Array.prototype.map.call(_commonDims, (el) => ({
+      name: el.getAttribute('name'),
+      field: el.getAttribute('field')
+    })).filter(dim => dim.name && dim.field)
+
+    if (commonDims.length > 0) {
+      commonDims.forEach(dim => Store.registerDimension(dim.name, new Function('d', `return ${dim.field}`), {dataset, common: true}))
+    }
+
     let p;
 
     if (mode) {


### PR DESCRIPTION
refs: #121 

`<easy-dc-dataset>` 内部に `<dimension name="name" field="d.name"></dimension>` のような形で設定するとCommon Dimensionが扱える
https://github.com/plaidev/easy-dc-dash/blob/b5f21e793b56cbcea8a3b77ef86fb06c8625dd43/docs/example/dashboard-04/index.html#L9-L12

これで
https://github.com/plaidev/easy-dc-dash/blob/b5f21e793b56cbcea8a3b77ef86fb06c8625dd43/docs/example/dashboard-04/index.html#L21-L25