### PR TITLE
[base-mixin] add ordering option

### DIFF
--- a/docs/example/dashboard-01/index.html
+++ b/docs/example/dashboard-01/index.html
@@ -116,12 +116,14 @@
     y-axis-label='pv'
     :show-x-axis-label='false'
     :show-y-axis-label='false'
+    ordering="asc"
   ></ordinal-bar>
 
   <ordinal-bar
     title='ordinal-bar'
     dimension='d.name'
     reduce='d.pv'
+    ordering="desc"
   ></ordinal-bar>
 
 

--- a/libs/chart/_base.js
+++ b/libs/chart/_base.js
@@ -146,6 +146,11 @@ export default {
       type: String
     },
 
+    // order
+    ordering: {
+      type: String
+    },
+
     // cap mixin
     cap: {
       type: Number,
@@ -718,6 +723,16 @@ export default {
         return d.key[0]
       })
     }
+    if (this.ordering) {
+      const ordering = this.ordering.toLowerCase();
+      if (ordering.startsWith('asc')) {
+        chart.ordering((d) => d.value)
+      }
+      else if (ordering.startsWith('desc')) {
+        chart.ordering((d) => -d.value)
+      }
+    }
+
 
     chart
       .renderLabel(this.renderLabel)


### PR DESCRIPTION
resolve #100 

base-mixinにordering optionがあった
http://dc-js.github.io/dc.js/docs/html/dc.baseMixin.html#ordering__anchor

これを使えば簡単にorder byができる

- pie, row, ordinal-barチャートで使える
