### PR TITLE
build timeを短縮する

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "http-server": "^0.9.0",
     "less": "^2.7.3",
     "rollup": "^0.48.2",
+    "rollup-analyzer-plugin": "^1.1.1",
     "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-commonjs": "^8.2.4",
     "rollup-plugin-css-only": "^0.2.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -67,7 +67,11 @@ export default {
 
     // ES5に変換。.babelrcは別途用意済み
     babel({
-      exclude: 'node_modules/**' // only transpile our source code
+      exclude: [
+        '**/*.json',
+        '**/*.scss',
+        'node_modules/**' // only transpile our source code
+      ]
     })
   ],
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,6 +10,7 @@ import css          from 'rollup-plugin-css-only'
 import json         from 'rollup-plugin-json'
 import nodeBuiltins from 'rollup-plugin-node-builtins'
 import nodeGlobals  from 'rollup-plugin-node-globals'
+import analyze      from 'rollup-analyzer-plugin'
 
 export default {
 
@@ -72,7 +73,9 @@ export default {
         '**/*.scss',
         'node_modules/**' // only transpile our source code
       ]
-    })
+    }),
+
+    // analyze()
   ],
 
   // d3 v3系が動かないので。

--- a/rollup.watch.config.js
+++ b/rollup.watch.config.js
@@ -10,6 +10,7 @@ import css          from 'rollup-plugin-css-only'
 import json         from 'rollup-plugin-json'
 import nodeBuiltins from 'rollup-plugin-node-builtins'
 import nodeGlobals  from 'rollup-plugin-node-globals'
+import analyze      from 'rollup-analyzer-plugin'
 
 export default {
 
@@ -71,7 +72,9 @@ export default {
         '**/*.scss',
         'node_modules/**' // only transpile our source code
       ]
-    })
+    }),
+
+    // analyze()
   ],
 
   // d3 v3系が動かないので。

--- a/rollup.watch.config.js
+++ b/rollup.watch.config.js
@@ -66,7 +66,11 @@ export default {
 
     // ES5に変換。.babelrcは別途用意済み
     babel({
-      exclude: 'node_modules/**' // only transpile our source code
+      exclude: [
+        '**/*.json',
+        '**/*.scss',
+        'node_modules/**' // only transpile our source code
+      ]
     })
   ],
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2877,6 +2877,16 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^2.0.0"
     inherits "^2.0.1"
 
+rollup-analyzer-plugin@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/rollup-analyzer-plugin/-/rollup-analyzer-plugin-1.1.1.tgz#617d3147b91b9a33b93133965223d55066d01650"
+  dependencies:
+    rollup-analyzer "^1.1.0"
+
+rollup-analyzer@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/rollup-analyzer/-/rollup-analyzer-1.1.0.tgz#057e1af0905e5f54e3045e2ffdaf7c8fc70ee5f3"
+
 rollup-plugin-babel@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rollup-plugin-babel/-/rollup-plugin-babel-2.7.1.tgz#16528197b0f938a1536f44683c7a93d573182f57"


### PR DESCRIPTION
close #146 

- `.json` と `.scss` をbabelの対象外とする
- rollup-analyzer-pluginを追加