### PR TITLE
Tooltip の左右表示位置切り替え 実装

### DIFF
--- a/libs/components/krt-dc-tooltip.vue
+++ b/libs/components/krt-dc-tooltip.vue
@@ -47,9 +47,18 @@ export default {
     },
     move: function(left, top) {
       if(!this.data) return
+      const winW = window.innerWidth;
       const el = this.$el;
-      el.style.left = (left + 50) + "px";
-      el.style.top = (top - 10) + "px";
+      
+      el.style = "";
+
+      if (left > winW/2) {
+        el.style.right = (winW - left + 10) + "px";
+        el.style.top = (top - 10) + "px";
+      } else {
+        el.style.left = (left + 50) + "px";
+        el.style.top = (top - 10) + "px";
+      }
     },
     remove: function() {
       this.data = null;


### PR DESCRIPTION
**内容：**
カーソル位置によって、tooltip の表示が切れてしまうことがあるので、画面中央を分岐点に Tooltip の左右表示切り替えの実装。

**Issue：**
#176